### PR TITLE
fix exclude_definitions in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The ```bids/details``` array is used to provide one or more ```Bid``` objects, e
 ```eval_rst
 .. extensiontable::
    :extension: bids
-   :exclude_definitions: BidStatistics
+   :exclude_definitions: statistics BidsStatistic 
 ```
 
 ### Example


### PR DESCRIPTION
fix bidsStatistic fields displaying under the bid details heading in the V1.1 docs:

![image](https://cloud.githubusercontent.com/assets/19265814/26411590/20caa6e2-409e-11e7-804e-4c1a858a58e9.png)
