### PR TITLE
BidStatistic should be BidsStatistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The OCDS bid extension introduces a new, flexible, top-level section to each con
 
 ### Bid Statistics
 
-The ```bids/bidStatistics``` array can be used to represent key statistical information about the number of bids and bidders. Each entry in the array is a ```BidStatistic``` object containing at least:
+The ```bids/bidStatistics``` array can be used to represent key statistical information about the number of bids and bidders. Each entry in the array is a ```BidsStatistic``` object containing at least:
 
 * An identifier;
 * A measure, from the bidStatistics codelist;


### PR DESCRIPTION
Not sure why the building block was named `BidsStatistic`, but the README should be consistent with that.