### PR TITLE
Add foreignBidsFromNonEU, align EU codes with EU language

### DIFF
--- a/codelists/bidStatistics.csv
+++ b/codelists/bidStatistics.csv
@@ -6,7 +6,8 @@ bidders,bidders,Bidders,The total number of unique organizations or consortia su
 bidders,qualifiedBidders,Qualified Bidders,The total number of unique organizations or consortia passing the qualification stage of the evaluation process.
 bidders,disqualifiedBidders,Disqualified Bidders,The total number of unique organizations or consortia that did not pass the qualification stage of the evaluation process.
 EU,electronicBids,Electronic Bids,The number of bids received by electronic means.
-EU,smeBids,Bids from SMEs,The number of bids received from Small and Medium Sized Enterprises
+EU,smeBids,Bids from SMEs,The number of bids received from small and medium-sized enterprises.
 EU,foreignBids,Bids from Foreign Firms,The number of bids received from bidders from outside the country where the tender is issued.
-EU,foreignBidsFromEU,Bids from firms in other EU single market countries,"The number of bids received from bidders from outside the country where the tender is issued, but based within another EU country, Iceland, Norway,or Liechtenstein."
+EU,foreignBidsFromEU,Bids from firms in other EU single market countries,"The number of bids received from tenderers from other EU Member States, Iceland, Norway, or Liechtenstein."
+EU,foreignBidsFromNonEU,Bids from firms in non-EU single market countries,The number of bids received from tenderers from non-EU Member States.
 EU,tendersAbnormallyLow,Tenders excluded because they were abnormally low,"The number of tenders excluded because they were abnormally low. Note that in some EU datasets this may have been converted from a boolean, such that a value of 1 would indicate '1 or more' tenders were excluded. Users should evaluate and interpret data accordingly."


### PR DESCRIPTION
closes open-contracting/ocds-extensions#69

The EU forms refer to Member States, not European Economic Area, so I don't know why the definition mentions Iceland, Norway, or Liechtenstein. Anyhow, we can't change semantics in a patch release, so I leave it there for the old code.