### PR TITLE
statistics.csv: Add codes for eForms

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * 'microBids'
   * 'smallBids'
   * 'mediumBids'
-  * 'tendersDisqualified'
+  * 'disqualifiedBids'
 
 ### v1.1.5
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 * Add guidance on correcting bid values
 * Rename the `BidStatistic` definition to `Statistic`, and remove bid-specific language from its fields' descriptions
 * Rename the `bidStatistics.csv` codelist to `statistic.csv`
+* Add codes to `statistic.csv`:
+  * 'microBids'
+  * 'smallBids'
+  * 'mediumBids'
+  * 'tendersDisqualified'
 
 ### v1.1.5
 

--- a/codelists/statistic.csv
+++ b/codelists/statistic.csv
@@ -9,7 +9,11 @@ bidders,qualifiedBidders,Qualified bidders,The total number of unique organizati
 bidders,disqualifiedBidders,Disqualified bidders,The total number of unique organizations or consortia that did not pass the qualification stage of the evaluation process.
 EU,electronicBids,Electronic bids,The number of bids received by electronic means.
 EU,smeBids,Bids from SMEs,The number of bids received from small and medium-sized enterprises.
+EU,microBids,Micro bids,Bids from micro companies
+EU,smallBids,Small bids,Bids from small companies
+EU,mediumBids,Medium bids,Bids from medium companies
 EU,foreignBids,Bids from foreign firms,The number of bids received from bidders from outside the country where the tender is issued.
 EU,foreignBidsFromEU,Bids from firms in other European Economic Area countries,The number of bids received from tenderers from other European Economic Area countries.
 EU,foreignBidsFromNonEU,Bids from firms in non-European Economic Area countries,The number of bids received from tenderers from non-European Economic Area countries.
 EU,tendersAbnormallyLow,Tenders excluded because they were abnormally low,"The number of tenders excluded because they were abnormally low. Note that in some EU datasets this might have been converted from a boolean, such that a value of 1 would indicate ""1 or more"" tenders were excluded. Users need to evaluate and interpret data accordingly."
+EU,tendersDisqualified,The number of excluded tenders

--- a/codelists/statistic.csv
+++ b/codelists/statistic.csv
@@ -8,12 +8,12 @@ bidders,bidders,Bidders,The total number of unique organizations or consortia su
 bidders,qualifiedBidders,Qualified bidders,The total number of unique organizations or consortia passing the qualification stage of the evaluation process.
 bidders,disqualifiedBidders,Disqualified bidders,The total number of unique organizations or consortia that did not pass the qualification stage of the evaluation process.
 EU,electronicBids,Electronic bids,The number of bids received by electronic means.
-EU,smeBids,Bids from SMEs,The number of bids received from small and medium-sized enterprises.
-EU,microBids,Bids from micro companies,The number of bids received from micro-sized enterprises.
-EU,smallBids,Bids from small companies,The number of bids received from small-sized enterprises.
-EU,mediumBids,Bids from medium companies,The number of bids received from medium-sized enterprises.
+EU,microBids,Bids from micro companies,The number of bids received from micro enterprises.
+EU,smeBids,Bids from SMEs,The number of bids received from small and medium enterprises.
+EU,smallBids,Bids from small companies,The number of bids received from small enterprises.
+EU,mediumBids,Bids from medium companies,The number of bids received from medium enterprises.
 EU,foreignBids,Bids from foreign firms,The number of bids received from bidders from outside the country where the tender is issued.
 EU,foreignBidsFromEU,Bids from firms in other European Economic Area countries,The number of bids received from tenderers from other European Economic Area countries.
 EU,foreignBidsFromNonEU,Bids from firms in non-European Economic Area countries,The number of bids received from tenderers from non-European Economic Area countries.
 EU,tendersAbnormallyLow,Tenders excluded because they were abnormally low,"The number of tenders excluded because they were abnormally low. Note that in some EU datasets this might have been converted from a boolean, such that a value of 1 would indicate ""1 or more"" tenders were excluded. Users need to evaluate and interpret data accordingly."
-EU,tendersDisqualified,Excluded tenders,"The number of tenders that were found inadmissible. A tender is found inadmissible where it has been verified that it has been submitted by a tenderer who has been excluded or who did not meet the selection criteria, or when it is not in conformity with the technical specifications, or is irregular (e.g. it was received late, having an abnormally low price or cost), unacceptable or unsuitable."
+EU,disqualifiedBids,Disqualified bids,"The number of bids that were found inadmissible. A bid is found inadmissible where it has been verified that it has been submitted by a tenderer who has been excluded or who did not meet the selection criteria, or when it is not in conformity with the technical specifications, or is irregular (e.g. it was received late, having an abnormally low price or cost), unacceptable or unsuitable."

--- a/codelists/statistic.csv
+++ b/codelists/statistic.csv
@@ -9,11 +9,11 @@ bidders,qualifiedBidders,Qualified bidders,The total number of unique organizati
 bidders,disqualifiedBidders,Disqualified bidders,The total number of unique organizations or consortia that did not pass the qualification stage of the evaluation process.
 EU,electronicBids,Electronic bids,The number of bids received by electronic means.
 EU,smeBids,Bids from SMEs,The number of bids received from small and medium-sized enterprises.
-EU,microBids,Micro bids,Bids from micro companies
-EU,smallBids,Small bids,Bids from small companies
-EU,mediumBids,Medium bids,Bids from medium companies
+EU,microBids,Bids from micro companies,The number of bids received from micro-sized enterprises.
+EU,smallBids,Bids from small companies,The number of bids received from small-sized enterprises.
+EU,mediumBids,Bids from medium companies,The number of bids received from medium-sized enterprises.
 EU,foreignBids,Bids from foreign firms,The number of bids received from bidders from outside the country where the tender is issued.
 EU,foreignBidsFromEU,Bids from firms in other European Economic Area countries,The number of bids received from tenderers from other European Economic Area countries.
 EU,foreignBidsFromNonEU,Bids from firms in non-European Economic Area countries,The number of bids received from tenderers from non-European Economic Area countries.
 EU,tendersAbnormallyLow,Tenders excluded because they were abnormally low,"The number of tenders excluded because they were abnormally low. Note that in some EU datasets this might have been converted from a boolean, such that a value of 1 would indicate ""1 or more"" tenders were excluded. Users need to evaluate and interpret data accordingly."
-EU,tendersDisqualified,The number of excluded tenders
+EU,tendersDisqualified,Excluded tenders,"The number of tenders that were found inadmissible. A tender is found inadmissible where it has been verified that it has been submitted by a tenderer who has been excluded or who did not meet the selection criteria, or when it is not in conformity with the technical specifications, or is irregular (e.g. it was received late, having an abnormally low price or cost), unacceptable or unsuitable."

--- a/codelists/statistic.csv
+++ b/codelists/statistic.csv
@@ -2,6 +2,7 @@ Category,Code,Title,Description
 bids,requests,Requests to participate,The total number of unique requests to participate received
 bids,bids,Bids,The total number of unique bids received (prior to any being discounted for not meeting essential criteria).
 bids,validBids,Valid bids,"The total number of unique bids received that were considered valid against relevant criteria (either of the bidder, or the bid submission itself). All valid bids are considered during the tender evaluation stage."
+EU,disqualifiedBids,Disqualified bids,"The number of bids that were found inadmissible. A bid is found inadmissible where it has been verified that it has been submitted by a tenderer who has been excluded or who did not meet the selection criteria, or when it is not in conformity with the technical specifications, or is irregular (e.g. it was received late, having an abnormally low price or cost), unacceptable or unsuitable."
 bids,lowestValidBidValue,Lowest valid bid value,The value of the lowest valid bid.
 bids,highestValidBidValue,Highest valid bid value,The value of the highest valid bid.
 bidders,bidders,Bidders,The total number of unique organizations or consortia submitting bids  (prior to any being discounted for not meeting essential criteria).
@@ -16,4 +17,3 @@ EU,foreignBids,Bids from foreign firms,The number of bids received from bidders 
 EU,foreignBidsFromEU,Bids from firms in other European Economic Area countries,The number of bids received from tenderers from other European Economic Area countries.
 EU,foreignBidsFromNonEU,Bids from firms in non-European Economic Area countries,The number of bids received from tenderers from non-European Economic Area countries.
 EU,tendersAbnormallyLow,Tenders excluded because they were abnormally low,"The number of tenders excluded because they were abnormally low. Note that in some EU datasets this might have been converted from a boolean, such that a value of 1 would indicate ""1 or more"" tenders were excluded. Users need to evaluate and interpret data accordingly."
-EU,disqualifiedBids,Disqualified bids,"The number of bids that were found inadmissible. A bid is found inadmissible where it has been verified that it has been submitted by a tenderer who has been excluded or who did not meet the selection criteria, or when it is not in conformity with the technical specifications, or is irregular (e.g. it was received late, having an abnormally low price or cost), unacceptable or unsuitable."


### PR DESCRIPTION
For 'tendersDisqualified', I omitted 'The number of' from the code's title, in keeping with the titles of other codes. If that sounds good, we should update the [received-submission-type mapping table](https://standard.open-contracting.org/profiles/eforms/latest/en/codelists/received-submission-type/). I also retained the EU nomenclature of 'tenders' (rather than 'bids') in keeping with the existing 'tendersAbnormallyLow' code.