### PR TITLE
update for eforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * `BidsStatistic.valueGross`
   * `Award.relatedBids`
   * `Contract.relatedBids`
+  * `Bid.identifiers`
 * Deprecate the `Award.relatedBid` field
 * Add guidance on correcting bid values
 * Rename the `BidStatistic` definition to `Statistic`, and remove bid-specific language from its fields' descriptions

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Below is an example of a bids extension:
         "id": "1",
         "date": "2016-12-09T01:00:00+01:00",
         "status": "valid",
+        "identifiers": [
+          {
+            "id": "bid-123-456",
+            "scheme": "internal"
+          }
+        ],
         "items": [
           {
             "id": "1",
@@ -155,6 +161,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ### Unreleased
 
 * Add fields:
+  * `Bid.identifiers`
   * `Bid.description`
   * `Bid.items`
   * `Bid.hasRank`
@@ -165,7 +172,6 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * `BidsStatistic.valueGross`
   * `Award.relatedBids`
   * `Contract.relatedBids`
-  * `Bid.identifiers`
 * Deprecate the `Award.relatedBid` field
 * Add guidance on correcting bid values
 * Rename the `BidStatistic` definition to `Statistic`, and remove bid-specific language from its fields' descriptions

--- a/release-schema.json
+++ b/release-schema.json
@@ -462,6 +462,17 @@
           "description": "A local identifier for this bid",
           "type": "string"
         },
+        "identifiers": {
+          "title": "Identifiers",
+          "description": "Identifiers for this bid. This field can be used to provide internal identifiers for the bid, such as identifiers from a buyer's document management system or procurement system.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SimpleIdentifier"
+          },
+          "wholeListMerge": true,
+          "uniqueItems": true,
+          "minItems": 1
+        },
         "date": {
           "title": "Date",
           "description": "The date when this bid was received.",
@@ -835,6 +846,33 @@
           ]
         }
       }
+    },
+    "SimpleIdentifier": {
+      "title": "Simple identifier",
+      "description": "An unambiguous reference to a resource within a given context.",
+      "type": "object",
+      "properties": {
+        "scheme": {
+          "title": "Scheme",
+          "description": "The list, register or system from which the identifier is taken.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "id": {
+          "title": "ID",
+          "description": "The identifier taken from the scheme.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "versionId": true,
+          "minLength": 1
+        }
+      },
+      "minProperties": 1
     }
   }
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -19,7 +19,8 @@
           "deprecated": {
             "description": "This field is deprecated in favor of `relatedBids`, to allow an award to combine multiple bids.",
             "deprecatedVersion": "1.2"
-          }
+          },
+          "minLength": 1
         },
         "relatedBids": {
           "title": "Related bids",
@@ -29,8 +30,11 @@
             "null"
           ],
           "items": {
-            "type": "string"
-          }
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
       }
     },
@@ -44,8 +48,11 @@
             "null"
           ],
           "items": {
-            "type": "string"
-          }
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
       }
     },
@@ -62,14 +69,16 @@
         "id": {
           "title": "ID",
           "description": "An internal identifier for this statistic.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "measure": {
           "title": "Measure",
           "description": "The statistic reported in the value.",
           "type": "string",
           "codelist": "statistic.csv",
-          "openCodelist": true
+          "openCodelist": true,
+          "minLength": 1
         },
         "date": {
           "title": "Date",
@@ -414,7 +423,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "minLength": 1
         },
         "relatedLot": {
           "title": "Related Lot",
@@ -422,9 +432,11 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "minLength": 1
         }
-      }
+      },
+      "minProperties": 1
     },
     "Bids": {
       "title": "Bids",
@@ -437,7 +449,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Statistic"
-          }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         },
         "details": {
           "title": "Bid details",
@@ -445,9 +459,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Bid"
-          }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
-      }
+      },
+      "minProperties": 1
     },
     "Bid": {
       "title": "Bid",
@@ -460,7 +477,8 @@
         "id": {
           "title": "ID",
           "description": "A local identifier for this bid",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifiers": {
           "title": "Identifiers",
@@ -488,7 +506,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "minLength": 1
         },
         "status": {
           "title": "Status",
@@ -515,7 +534,8 @@
           "items": {
             "$ref": "#/definitions/Item"
           },
-          "uniqueItems": true
+          "uniqueItems": true,
+          "minItems": 1
         },
         "tenderers": {
           "title": "Tenderer",
@@ -523,7 +543,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/OrganizationReference"
-          }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         },
         "value": {
           "title": "Value",
@@ -542,7 +564,8 @@
           "items": {
             "$ref": "#/definitions/Document"
           },
-          "uniqueItems": true
+          "uniqueItems": true,
+          "minItems": 1
         },
         "relatedLots": {
           "title": "Related lot(s)",
@@ -552,8 +575,11 @@
             "null"
           ],
           "items": {
-            "type": "string"
-          }
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
         },
         "countriesOfOrigin": {
           "title": "Countries of origin",
@@ -819,7 +845,9 @@
           },
           "codelist": "country.csv",
           "openCodelist": false,
-          "minLength": 1
+          "minLength": 1,
+          "minItems": 1,
+          "uniqueItems": true
         },
         "hasRank": {
           "title": "Has rank",
@@ -845,7 +873,8 @@
             "null"
           ]
         }
-      }
+      },
+      "minProperties": 1
     },
     "SimpleIdentifier": {
       "title": "Simple identifier",

--- a/release-schema.json
+++ b/release-schema.json
@@ -460,8 +460,7 @@
         "id": {
           "title": "ID",
           "description": "A local identifier for this bid",
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "identifiers": {
           "title": "Identifiers",
@@ -471,7 +470,8 @@
             "$ref": "#/definitions/SimpleIdentifier"
           },
           "wholeListMerge": true,
-          "uniqueItems": true
+          "uniqueItems": true,
+          "minItems": 1
         },
         "date": {
           "title": "Date",
@@ -858,7 +858,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "minLength": 1
         },
         "id": {
           "title": "ID",
@@ -866,9 +867,12 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "versionId": true,
+          "minLength": 1
         }
-      }
+      },
+      "minProperties": 1
     }
   }
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -19,8 +19,7 @@
           "deprecated": {
             "description": "This field is deprecated in favor of `relatedBids`, to allow an award to combine multiple bids.",
             "deprecatedVersion": "1.2"
-          },
-          "minLength": 1
+          }
         },
         "relatedBids": {
           "title": "Related bids",
@@ -30,11 +29,8 @@
             "null"
           ],
           "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1,
-          "uniqueItems": true
+            "type": "string"
+          }
         }
       }
     },
@@ -48,11 +44,8 @@
             "null"
           ],
           "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1,
-          "uniqueItems": true
+            "type": "string"
+          }
         }
       }
     },
@@ -69,16 +62,14 @@
         "id": {
           "title": "ID",
           "description": "An internal identifier for this statistic.",
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "measure": {
           "title": "Measure",
           "description": "The statistic reported in the value.",
           "type": "string",
           "codelist": "statistic.csv",
-          "openCodelist": true,
-          "minLength": 1
+          "openCodelist": true
         },
         "date": {
           "title": "Date",
@@ -423,8 +414,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "minLength": 1
+          ]
         },
         "relatedLot": {
           "title": "Related Lot",
@@ -432,11 +422,9 @@
           "type": [
             "string",
             "null"
-          ],
-          "minLength": 1
+          ]
         }
-      },
-      "minProperties": 1
+      }
     },
     "Bids": {
       "title": "Bids",
@@ -449,9 +437,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Statistic"
-          },
-          "minItems": 1,
-          "uniqueItems": true
+          }
         },
         "details": {
           "title": "Bid details",
@@ -459,12 +445,9 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Bid"
-          },
-          "minItems": 1,
-          "uniqueItems": true
+          }
         }
-      },
-      "minProperties": 1
+      }
     },
     "Bid": {
       "title": "Bid",
@@ -488,8 +471,7 @@
             "$ref": "#/definitions/SimpleIdentifier"
           },
           "wholeListMerge": true,
-          "uniqueItems": true,
-          "minItems": 1
+          "uniqueItems": true
         },
         "date": {
           "title": "Date",
@@ -506,8 +488,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "minLength": 1
+          ]
         },
         "status": {
           "title": "Status",
@@ -534,8 +515,7 @@
           "items": {
             "$ref": "#/definitions/Item"
           },
-          "uniqueItems": true,
-          "minItems": 1
+          "uniqueItems": true
         },
         "tenderers": {
           "title": "Tenderer",
@@ -543,9 +523,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/OrganizationReference"
-          },
-          "minItems": 1,
-          "uniqueItems": true
+          }
         },
         "value": {
           "title": "Value",
@@ -564,8 +542,7 @@
           "items": {
             "$ref": "#/definitions/Document"
           },
-          "uniqueItems": true,
-          "minItems": 1
+          "uniqueItems": true
         },
         "relatedLots": {
           "title": "Related lot(s)",
@@ -575,11 +552,8 @@
             "null"
           ],
           "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1,
-          "uniqueItems": true
+            "type": "string"
+          }
         },
         "countriesOfOrigin": {
           "title": "Countries of origin",
@@ -845,9 +819,7 @@
           },
           "codelist": "country.csv",
           "openCodelist": false,
-          "minLength": 1,
-          "minItems": 1,
-          "uniqueItems": true
+          "minLength": 1
         },
         "hasRank": {
           "title": "Has rank",
@@ -873,8 +845,7 @@
             "null"
           ]
         }
-      },
-      "minProperties": 1
+      }
     },
     "SimpleIdentifier": {
       "title": "Simple identifier",
@@ -887,8 +858,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "minLength": 1
+          ]
         },
         "id": {
           "title": "ID",
@@ -896,12 +866,9 @@
           "type": [
             "string",
             "null"
-          ],
-          "versionId": true,
-          "minLength": 1
+          ]
         }
-      },
-      "minProperties": 1
+      }
     }
   }
 }


### PR DESCRIPTION
Adding `identifiers` array and the `SimpleIdentifier` definition as is done in the current Lots extension. This is needed for BT-3201

`ocdskit schema-strict` has been run